### PR TITLE
Fixed HREF bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -183,7 +183,7 @@ const App = (function (StorageCtrl, UICtrl) {
     if (videoId === null || videoId === '') {
       UICtrl.legendState();
     }
-    const href = `${window.location.origin}${window.location.pathname}#${videoId}`;
+    const href = `#${videoId}`;
     window.location.href = href;
     window.location.reload();
 


### PR DESCRIPTION
On testing this on other machines, I noticed that the URL would not load when opening a new Youtube video; it would just get stuck with a `?` after the URL. 

This was fixed through leaving out everything but the suffix in the `window.location.href`, which is `#{video-id}`.