### PR TITLE
Added compatibility for screens > 960px

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,7 +14,6 @@
 .container {
   position: relative;
   width: 100%;
-  max-width: 960px;
   margin: 0 auto;
   padding: 0 20px;
   box-sizing: border-box;


### PR DESCRIPTION
On testing this on a large screen device, I noticed that Skeleton CSS limits the maximum container width to 960px. I removed this rule and allowed for larger videos and more room to write on those screens.